### PR TITLE
Dev

### DIFF
--- a/util.rkt
+++ b/util.rkt
@@ -10,6 +10,13 @@
 
 (define-syntax-rule (launch-for-ratchet exp)
   (begin
+    exp
+    "Game complete")
+
+  #;
+  (begin
     (thread  ;For some reason, running inside a thread makes subsequent runs faster.  Like the game cleans up after itself better in a thread.  But I'm not sure what's being cleaned up.  Physics?  Some other memory with lux or mode-lambda?
       (thunk exp))
-    "Please wait...."))
+    "Please wait....")
+  
+  )

--- a/visual-language-maker/gui/widgets/basic-input-editor.rkt
+++ b/visual-language-maker/gui/widgets/basic-input-editor.rkt
@@ -74,11 +74,7 @@
   
   (define picts (map identifier-mapping-picture mappings))
 
-  ;DON"T HARD CODE THIS BIT>>>>
-  ;(dynamic-require 'k2/lang/ocean/fish #f)
-  (define ns
-    (visual-language-ns vis-lang)
-    #;(module->namespace 'k2/lang/ocean/fish))
+  (define ns (visual-language-ns vis-lang))
     
   (define visual-editor%
     (class racket:text%
@@ -130,7 +126,9 @@
           (eval
             (read
               (open-input-string code))
-            ns))))
+            ns)
+          
+          )))
 
   visual-editor%)
 

--- a/visual-language-maker/gui/widgets/main.rkt
+++ b/visual-language-maker/gui/widgets/main.rkt
@@ -70,6 +70,7 @@
                                    f))]
                           [else (send-to-editor output-editor (sanitize result))])
 
+                        ;Hack...
                         (if (please-wait? result)
                           (thread
                             (thunk

--- a/visual-language-maker/gui/widgets/main.rkt
+++ b/visual-language-maker/gui/widgets/main.rkt
@@ -70,7 +70,15 @@
                                    f))]
                           [else (send-to-editor output-editor (sanitize result))])
 
-                        ;Hack...
+                        ;Hack...  But I think we don't need it anymore,
+                        ;since we allow game-engine games to run to completion before 
+                        ;the run button needs to be reenabled.  So it just waits until
+                        ;the game is finished before you can launch another one.
+                        ;Exactly what we want.
+                        ;I'll leave this here for now, in case we need to fall back
+                        ;to the hackier solution.
+                        
+                        #;
                         (if (please-wait? result)
                           (thread
                             (thunk


### PR DESCRIPTION
Fixes some bugs with slow 2nd runs of games, but without adding the additional bugs of messed up sprite databases and the flaky "Run" button.

It seems as if the slow-down was being caused by outputting the game state and piping it into the Ratchet output window.  Now, I'm just outputting "Game complete" -- which has fixed the problem.  I'm not sure what was going on here -- probably the game was not getting garbage collected, or something.